### PR TITLE
Support Python 3.14 and Django 6.0

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,11 +20,11 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/djpsa/__init__.py
+++ b/djpsa/__init__.py
@@ -2,5 +2,3 @@
 from importlib.metadata import version
 
 __version__ = version("django-psa")
-
-default_app_config = 'djpsa.sync.apps.SyncConfig'

--- a/djpsa/halo/records/appointment/sync.py
+++ b/djpsa/halo/records/appointment/sync.py
@@ -1,3 +1,4 @@
+from datetime import UTC
 from typing import Any, List
 from django.utils import timezone
 from dateutil.parser import parse
@@ -54,12 +55,12 @@ class AppointmentSynchronizer(sync.CreateMixin,
         instance.subject = json_data.get('subject')
         start_date = json_data.get('start_date')
         instance.start_date = timezone.make_aware(
-            parse(start_date), timezone.utc
+            parse(start_date), UTC
         ) if start_date else None
 
         end_date = json_data.get('end_date')
         instance.end_date = timezone.make_aware(
-            parse(end_date), timezone.utc
+            parse(end_date), UTC
         ) if end_date else None
         instance.appointment_type = json_data.get('appointment_type_name')
         instance.is_private = json_data.get('is_private')

--- a/djpsa/halo/records/ticket/sync.py
+++ b/djpsa/halo/records/ticket/sync.py
@@ -1,3 +1,4 @@
+from datetime import UTC
 from typing import Any, List
 
 from django.utils import timezone
@@ -72,7 +73,7 @@ class TicketSynchronizer(sync.ResponseKeyMixin,
 
         try:
             instance.last_action_date = timezone.make_aware(
-                parse(json_data.get('lastactiondate')), timezone.utc)
+                parse(json_data.get('lastactiondate')), UTC)
         except ValueError:
             instance.last_action_date = parse(json_data.get('lastactiondate'))
 
@@ -84,7 +85,7 @@ class TicketSynchronizer(sync.ResponseKeyMixin,
         if last_update:
             try:
                 instance.last_update = timezone.make_aware(
-                    parse(last_update), timezone.utc)
+                    parse(last_update), UTC)
             except ValueError:
                 instance.last_update = parse(last_update)
 

--- a/djpsa/halo/sync.py
+++ b/djpsa/halo/sync.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date, datetime, time
+from datetime import UTC, date, datetime, time
 
 from django.utils import timezone
 from dateutil.parser import parse
@@ -33,7 +33,7 @@ def empty_date_parser(date_time):
     # Set to 1980 in case they also do 1950 or something and I haven't seen it.
     if date_time:
         try:
-            date_time = timezone.make_aware(parse(date_time), timezone.utc)
+            date_time = timezone.make_aware(parse(date_time), UTC)
         except ValueError:
             date_time = parse(date_time)
         return date_time if date_time.year > 1980 else None
@@ -50,7 +50,7 @@ def parse_date_from_api(date_time_str):
 
     # Ensure it's UTC-aware
     if timezone.is_naive(parsed_datetime):
-        parsed_datetime = timezone.make_aware(parsed_datetime, timezone.utc)
+        parsed_datetime = timezone.make_aware(parsed_datetime, UTC)
 
     # Extract the date portion
     return parsed_datetime.date()
@@ -76,7 +76,7 @@ def format_date_for_api(date_value):
         server_tz
     )
 
-    utc_noon = server_noon.astimezone(timezone.utc)
+    utc_noon = server_noon.astimezone(UTC)
     # Format as ISO string without timezone indicator
     return utc_noon.strftime('%Y-%m-%dT%H:%M:%S')
 

--- a/djpsa/halo/tests/test_sync.py
+++ b/djpsa/halo/tests/test_sync.py
@@ -1,3 +1,4 @@
+from datetime import UTC
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, patch
 from django.utils import timezone
@@ -13,7 +14,7 @@ class TestEmptyDateParser(TestCase):
 
     def test_valid_date(self):
         date_str = "2023-10-10T10:00:00"
-        expected_date = timezone.make_aware(parse(date_str), timezone.utc)
+        expected_date = timezone.make_aware(parse(date_str), UTC)
         self.assertEqual(empty_date_parser(date_str), expected_date)
 
     def test_empty_date(self):
@@ -29,7 +30,7 @@ class TestEmptyDateParser(TestCase):
 
     def test_above_edge_case_date(self):
         date_str = "1981-01-01T00:00:00"
-        expected_date = timezone.make_aware(parse(date_str), timezone.utc)
+        expected_date = timezone.make_aware(parse(date_str), UTC)
         self.assertEqual(empty_date_parser(date_str), expected_date)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-django==4.2.20
+django==6.0.7
 requests
-setuptools==75.3.2
-python-dateutil==2.8.2
+setuptools==83.0.0
+python-dateutil==2.9.0.post0
 retrying
-django-model-utils==4.3.1
-redis==4.5.4
-build==1.2.2.post1
+django-model-utils==5.0.0
+redis==8.1.0
+build==1.5.0
 django-extensions
+django-braces

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 LONG_DESCRIPTION = open('README.md').read()
 
-VERSION = (0, 34, '0')
+VERSION = (0, 35, '0')
 
 # pragma: no cover
 if VERSION[-1] != "final":
@@ -30,28 +30,17 @@ setup(
     url="https://github.com/topleft-team/django-psa",
     include_package_data=True,
     license='MIT',
+    python_requires='>=3.12',
     install_requires=[
         'requests',
-        'django',
+        'django>=4.2,<7.0',
         'setuptools',
         'python-dateutil',
         'retrying',
         'redis',
         'django-extensions',
-    ],
-    test_suite='runtests.suite',
-    tests_require=[
-        'names',
-        'coverage',
-        'flake8',
-        'django-test-plus',
-        'mock',
-        'freezegun',
-        'responses',
-        'model-mommy',
-        'django-coverage',
-        'names',
-        'django-environ'
+        'django-model-utils',
+        'django-braces',
     ],
     # Django likes to inspect apps for /migrations directories, and can't if
     # package is installed as an egg. zip_safe=False disables installation as
@@ -60,11 +49,16 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Replace django.utils.timezone.utc, removed in Django 5.0, with the stdlib datetime.UTC. This was the only runtime break; it stays compatible with Django 4.2 and 5.2, both of which still pass the suite.

Packaging:
- Pin requirements.txt to Django 6.0 and bump setuptools, python-dateutil, django-model-utils, redis and build to versions with 3.14 wheels.
- Add python_requires>=3.12 (Django 6.0's floor), bound django<7.0, and add Python 3.12-3.14 / Django 4.2-6.0 classifiers.
- Declare django-braces and django-model-utils in install_requires. Both are imported at runtime (halo.views, and FieldTracker across the model modules) but were previously undeclared, so halo.urls and halo.views failed to import unless the dependency happened to be present.
- Drop test_suite and tests_require, which setuptools ignores and warns about, and the deprecated License classifier. License: MIT is still emitted from the license field.
- Drop default_app_config, unsupported since Django 4.1.

CI: build on Python 3.14, and bump checkout/setup-python, since setup-python@v3 cannot resolve 3.14.